### PR TITLE
Increase limit on the bodyParsers so that large NodeRED flows can deploy

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,8 +112,8 @@ app.use(function (req, res, next) {
 app.use(helmet());
 app.use(cors());
 app.use(logger('dev'));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json({limit: '20mb'}));
+app.use(bodyParser.urlencoded({ extended: false, limit: '20mb' }));
 app.use(cookieParser());
 app.use(i18n.init);
 


### PR DESCRIPTION
I think it default so 100kb.  Large flows, particularly those with lots of double byte characters, cannot deploy in the out of the box NodeRed we embed here.  I tested in 2 tenants. 